### PR TITLE
Add simple financial snapshot CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
-# curly-telegram
+# Curly Telegram
+
+This repository contains a simple command-line tool for viewing a personal financial snapshot.
+
+## Setup
+
+1. Ensure you have Python 3 installed.
+2. Clone the repository or download the files.
+
+## Usage
+
+Run the script from the project root:
+
+```bash
+python financial_snapshot.py
+```
+
+By default it reads data from `data/sample_financial_data.json`. You can provide your own JSON file with the `-f` option:
+
+```bash
+python financial_snapshot.py -f path/to/your_data.json
+```
+
+The script will display totals for assets, liabilities, net worth, income, expenses, and cash flow.
+
+## Data Format
+
+The JSON file should contain keys for `accounts`, `income`, and `expenses` similar to the sample file in the `data/` folder.
+

--- a/data/sample_financial_data.json
+++ b/data/sample_financial_data.json
@@ -1,0 +1,17 @@
+{
+  "accounts": [
+    {"name": "Checking", "type": "asset", "balance": 5000.0},
+    {"name": "Savings", "type": "asset", "balance": 15000.0},
+    {"name": "Mortgage", "type": "liability", "balance": 200000.0},
+    {"name": "Credit Card", "type": "liability", "balance": 3000.0}
+  ],
+  "income": [
+    {"source": "Salary", "amount": 6000.0},
+    {"source": "Rental", "amount": 1200.0}
+  ],
+  "expenses": [
+    {"category": "Rent", "amount": 2000.0},
+    {"category": "Utilities", "amount": 300.0},
+    {"category": "Groceries", "amount": 400.0}
+  ]
+}

--- a/financial_snapshot.py
+++ b/financial_snapshot.py
@@ -1,0 +1,56 @@
+import json
+import argparse
+
+
+def load_data(path):
+    with open(path) as f:
+        return json.load(f)
+
+
+def summarize(data):
+    assets_total = sum(acc["balance"] for acc in data.get("accounts", []) if acc.get("type") == "asset")
+    liabilities_total = sum(acc["balance"] for acc in data.get("accounts", []) if acc.get("type") == "liability")
+    net_worth = assets_total - liabilities_total
+
+    income_total = sum(item["amount"] for item in data.get("income", []))
+    expenses_total = sum(item["amount"] for item in data.get("expenses", []))
+    cash_flow = income_total - expenses_total
+
+    return {
+        "assets": assets_total,
+        "liabilities": liabilities_total,
+        "net_worth": net_worth,
+        "income": income_total,
+        "expenses": expenses_total,
+        "cash_flow": cash_flow,
+    }
+
+
+def display_summary(summary):
+    print("===== Financial Snapshot =====")
+    print(f"Total Assets:     ${summary['assets']:.2f}")
+    print(f"Total Liabilities:${summary['liabilities']:.2f}")
+    print(f"Net Worth:        ${summary['net_worth']:.2f}\n")
+    print(f"Monthly Income:   ${summary['income']:.2f}")
+    print(f"Monthly Expenses: ${summary['expenses']:.2f}")
+    print(f"Monthly Cash Flow:${summary['cash_flow']:.2f}")
+    print("==============================")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Simple financial snapshot")
+    parser.add_argument(
+        "-f",
+        "--file",
+        default="data/sample_financial_data.json",
+        help="Path to financial data JSON",
+    )
+    args = parser.parse_args()
+
+    data = load_data(args.file)
+    summary = summarize(data)
+    display_summary(summary)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `financial_snapshot.py` script to show a basic net worth snapshot from a JSON file
- add sample financial data
- expand README with usage instructions

## Testing
- `python financial_snapshot.py`

------
https://chatgpt.com/codex/tasks/task_e_6851b2a7ab7083318a24ac6b5e3a1084